### PR TITLE
Memoize rule lookup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-override",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Override clashing tailwind classes",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "precommit": "lint-staged && yarn run lint",
     "prepublish": "npm run build",
     "test": "jest",
+    "test:performance": "jest --group=performance",
     "test:slow": "jest --group=slow",
     "test:unit": "jest --group=unit",
     "test:watch": "nodemon -w ./src -w ./test -e ts,tsx --exec 'yarn run test'"
@@ -38,6 +39,7 @@
       "git add"
     ]
   },
+  "dependencies": {},
   "devDependencies": {
     "@types/jest": "^26.0.24",
     "@types/lodash": "^4.14.150",

--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,11 @@ overrideTailwindClasses('prefix-pt-2 prefix-pt-4', { prefix: 'prefix-' })
 Defaults to `true`
 
 ```js
+overrideTailwindClasses('!text-[#aabbcc]/5 !text-[#ffaa11]/25', { jit: true })
+// => '!text-[#ffaa11]/25'
+```
+
+```js
 overrideTailwindClasses('!text-[#aabbcc]/5 !text-[#ffaa11]/25', { jit: false })
 // => '!text-[#aabbcc]/5 !text-[#ffaa11]/25'
 ```
@@ -111,7 +116,6 @@ Defaults to: `true`
 If set to true the library caches lookups for the same class e.g. `text-pink-200`, so next time it will not need to look up the rule again.
 
 ```js
-// Slower, but uses less memory
 overrideTailwindClasses('text-pink-200 text-pink-300', { ruleLookupCache: true })
 // => 'text-pink-200' and 'text-pink-300' rules now cached, won't be looked up again
 ```

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,12 @@ import { overrideTailwindClasses } from 'tailwind-override'
 export const classNames = (...args) => overrideTailwindClasses(classNamesOriginal(...args))
 ```
 
-## Prefixes
+## Options
+
+
+### Prefix
+
+Defaults to `''`
 
 Supports Tailwinds prefix functionality.
 
@@ -90,11 +95,23 @@ overrideTailwindClasses('prefix-pt-2 prefix-pt-4', { prefix: 'prefix-' })
 // => 'prefix-pt-4'
 ```
 
-## Without tailwind jit
+### Tailwind jit
 
-Supports Tailwinds 'variants' functionality.
+Defaults to `true`
 
 ```js
 overrideTailwindClasses('!text-[#aabbcc]/5 !text-[#ffaa11]/25', { jit: false })
 // => '!text-[#aabbcc]/5 !text-[#ffaa11]/25'
+```
+
+### Cache rule look ups
+
+Defaults to: `true`
+
+If set to true the library caches lookups for the same class e.g. `text-pink-200`, so next time it will not need to look up the rule again.
+
+```js
+// Slower, but uses less memory
+overrideTailwindClasses('text-pink-200 text-pink-300', { ruleLookupCache: true })
+// => 'text-pink-200' and 'text-pink-300' rules now cached, won't be looked up again
 ```

--- a/readme.md
+++ b/readme.md
@@ -88,16 +88,18 @@ export const classNames = (...args) => overrideTailwindClasses(classNamesOrigina
 
 Defaults to `''`
 
-Supports Tailwinds prefix functionality.
+Supports Tailwind's prefix functionality.
 
 ```js
 overrideTailwindClasses('prefix-pt-2 prefix-pt-4', { prefix: 'prefix-' })
 // => 'prefix-pt-4'
 ```
 
-### Tailwind jit
+### Jit
 
 Defaults to `true`
+
+Supportss Tailwind's jit syntax.
 
 ```js
 overrideTailwindClasses('!text-[#aabbcc]/5 !text-[#ffaa11]/25', { jit: true })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import memoize from './vendor/fastMemoize'
 import { getRules } from './rules'
 
 const defaultOptions = {
@@ -8,9 +9,14 @@ const defaultOptions = {
 
 export type Options = { prefix: string; jit: boolean; ruleLookupCache: boolean }
 
-export const findTailwindProperties = (className, options: Options = { prefix: '', jit: true, ruleLookupCache: true }) => {
+const findTailwindPropertiesRaw = (className, options: Options) => {
   return getRules(options).find((rule) => rule.regex.test(className))?.properties
 }
+
+const findTailwindPropertiesMemoized = memoize(findTailwindPropertiesRaw)
+
+export const findTailwindProperties = (className: string, options: Options = defaultOptions) =>
+  options.ruleLookupCache ? findTailwindPropertiesMemoized(className, options) : findTailwindPropertiesRaw(className, options)
 
 const tailWindPremableEndIndex = (className) => className.lastIndexOf(':')
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,12 @@ import { getRules } from './rules'
 const defaultOptions = {
   prefix: '',
   jit: true,
+  ruleLookupCache: true,
 }
 
-export type Options = { prefix: string; jit: boolean }
+export type Options = { prefix: string; jit: boolean; ruleLookupCache: boolean }
 
-export const findTailwindProperties = (className, options: Options = { prefix: '', jit: true }) => {
+export const findTailwindProperties = (className, options: Options = { prefix: '', jit: true, ruleLookupCache: true }) => {
   return getRules(options).find((rule) => rule.regex.test(className))?.properties
 }
 

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1,8 +1,9 @@
+import memoize from './vendor/fastMemoize'
 import { Options } from './index'
 
 const MATCHES_NOTHING = `a^`
 
-export const getRules = ({ prefix, jit }: Options) => {
+const lookupRule = ({ prefix, jit }: Options) => {
   const arbitaryValue = jit ? `\\[.+\\]` : MATCHES_NOTHING
 
   const number = `((\\d|\\.|/)+|${arbitaryValue})`
@@ -876,3 +877,7 @@ export const getRules = ({ prefix, jit }: Options) => {
   ]
   return rules.map((rule) => ({ regex: new RegExp(`^${prefix}${rule.regex}$`), properties: rule.properties }))
 }
+
+const memoizedlookupRule = memoize(lookupRule)
+
+export const getRules = (options: Options) => (options.ruleLookupCache ? memoizedlookupRule(options) : lookupRule(options))

--- a/src/vendor/fastMemoize/index.js
+++ b/src/vendor/fastMemoize/index.js
@@ -1,0 +1,117 @@
+/* eslint-disable */
+
+//
+// Main
+//
+
+function memoize(fn, options) {
+  var cache = options && options.cache ? options.cache : cacheDefault
+
+  var serializer = options && options.serializer ? options.serializer : serializerDefault
+
+  var strategy = options && options.strategy ? options.strategy : strategyDefault
+
+  return strategy(fn, {
+    cache: cache,
+    serializer: serializer,
+  })
+}
+
+//
+// Strategy
+//
+
+function isPrimitive(value) {
+  return value == null || typeof value === 'number' || typeof value === 'boolean' // || typeof value === "string" 'unsafe' primitive for our needs
+}
+
+function monadic(fn, cache, serializer, arg) {
+  var cacheKey = isPrimitive(arg) ? arg : serializer(arg)
+
+  var computedValue = cache.get(cacheKey)
+  if (typeof computedValue === 'undefined') {
+    computedValue = fn.call(this, arg)
+    cache.set(cacheKey, computedValue)
+  }
+
+  return computedValue
+}
+
+function variadic(fn, cache, serializer) {
+  var args = Array.prototype.slice.call(arguments, 3)
+  var cacheKey = serializer(args)
+
+  var computedValue = cache.get(cacheKey)
+  if (typeof computedValue === 'undefined') {
+    computedValue = fn.apply(this, args)
+    cache.set(cacheKey, computedValue)
+  }
+
+  return computedValue
+}
+
+function assemble(fn, context, strategy, cache, serialize) {
+  return strategy.bind(context, fn, cache, serialize)
+}
+
+function strategyDefault(fn, options) {
+  var strategy = fn.length === 1 ? monadic : variadic
+
+  return assemble(fn, this, strategy, options.cache.create(), options.serializer)
+}
+
+function strategyVariadic(fn, options) {
+  var strategy = variadic
+
+  return assemble(fn, this, strategy, options.cache.create(), options.serializer)
+}
+
+function strategyMonadic(fn, options) {
+  var strategy = monadic
+
+  return assemble(fn, this, strategy, options.cache.create(), options.serializer)
+}
+
+//
+// Serializer
+//
+
+function serializerDefault() {
+  return JSON.stringify(arguments)
+}
+
+//
+// Cache
+//
+
+function ObjectWithoutPrototypeCache() {
+  this.cache = Object.create(null)
+}
+
+ObjectWithoutPrototypeCache.prototype.has = function (key) {
+  return key in this.cache
+}
+
+ObjectWithoutPrototypeCache.prototype.get = function (key) {
+  return this.cache[key]
+}
+
+ObjectWithoutPrototypeCache.prototype.set = function (key, value) {
+  this.cache[key] = value
+}
+
+var cacheDefault = {
+  create: function create() {
+    return new ObjectWithoutPrototypeCache()
+  },
+}
+
+//
+// API
+//
+
+module.exports = memoize
+module.exports.strategies = {
+  variadic: strategyVariadic,
+  monadic: strategyMonadic,
+}

--- a/src/vendor/fastMemoize/readme.md
+++ b/src/vendor/fastMemoize/readme.md
@@ -1,0 +1,2 @@
+This folder contains a copy of the code from:
+https://github.com/leobalter/fast-memoize library to keep the project 0 dependencies

--- a/src/vendor/fastMemoize/types.d.ts
+++ b/src/vendor/fastMemoize/types.d.ts
@@ -1,0 +1,38 @@
+/* eslint-disable */
+
+type Func = (...args: any[]) => any
+
+export interface Cache<K, V> {
+  create: CacheCreateFunc<K, V>
+}
+
+interface CacheCreateFunc<K, V> {
+  (): {
+    get(key: K): V
+    set(key: K, value: V): void
+    has(key: K): boolean
+  }
+}
+
+export type Serializer = (args: any[]) => string
+
+export interface Options<F extends Func> {
+  cache?: Cache<string, ReturnType<F>>
+  serializer?: Serializer
+  strategy?: MemoizeFunc
+}
+
+export interface MemoizeFunc {
+  <F extends Func>(fn: F, options?: Options<F>): F
+}
+
+interface Memoize extends MemoizeFunc {
+  strategies: {
+    variadic: MemoizeFunc
+    monadic: MemoizeFunc
+  }
+}
+
+declare const memoize: Memoize
+
+export default memoize

--- a/test/arbitaryValuesRules.test.ts
+++ b/test/arbitaryValuesRules.test.ts
@@ -485,7 +485,7 @@ const testCases = [
 for (const testCase of testCases) {
   test(`${testCase.classStartsWith}[value] returns expectedProperties: ${testCase.expectedProperties}`, () => {
     const className = `${testCase.classStartsWith}[value]`
-    const properties = _.sortBy(findTailwindProperties(className, { prefix: '', jit: true }))
+    const properties = _.sortBy(findTailwindProperties(className, { prefix: '', jit: true, ruleLookupCache: false }))
     const expectedProperties = _.sortBy(testCase.expectedProperties)
     expect(properties).toStrictEqual(expectedProperties)
   })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3,19 +3,9 @@
  */
 import { Options, overrideTailwindClasses } from '../src/index'
 
-import { defaultTestCases, ruleBasedTestCases, jitTestCases } from './testCases'
+import { allTestCases } from './testCases'
 
-const nonJitTestCases = [...defaultTestCases, ...ruleBasedTestCases].flatMap((testCase) => {
-  return [false, true].map((jit) => ({
-    ...testCase,
-    options: {
-      ...testCase.options,
-      jit: jit,
-    },
-  }))
-})
-
-for (const testCase of [...nonJitTestCases, ...jitTestCases]) {
+for (const testCase of allTestCases) {
   test(`overrideTailwindClasses('${testCase.input}', ${testCase.options}) returns '${testCase.expectedOutput}'`, () => {
     expect(overrideTailwindClasses(testCase.input, testCase.options as Options)).toBe(testCase.expectedOutput)
   })

--- a/test/performance.test.ts
+++ b/test/performance.test.ts
@@ -21,7 +21,7 @@ const duplicatedTestCases = _.times(1000).flatMap(() => allTestCases)
 test(`overrideTailwindClasses performance`, () => {
   const start = performance.now()
   for (const testCase of duplicatedTestCases) {
-    overrideTailwindClasses(testCase.input, { ...testCase.options, ruleLookupCache: false } as Options)
+    overrideTailwindClasses(testCase.input, testCase.options as Options)
   }
   const end = performance.now()
   expect(end - start).toBeLessThan(1000)

--- a/test/performance.test.ts
+++ b/test/performance.test.ts
@@ -8,25 +8,21 @@ import { Options, overrideTailwindClasses } from '../src/index'
 import { allTestCases } from './testCases'
 
 test(`overrideTailwindClasses performance`, () => {
-  console.log('number of tests: ', allTestCases.length)
   const start = performance.now()
   for (const testCase of allTestCases) {
     overrideTailwindClasses(testCase.input, { ...testCase.options, ruleLookupCache: false } as Options)
   }
   const end = performance.now()
-  console.log(start, end, end - start)
   expect(end - start).toBeLessThan(300)
 })
 
 const duplicatedTestCases = _.times(1000).flatMap(() => allTestCases)
 
 test(`overrideTailwindClasses performance`, () => {
-  console.log('number of tests: ', duplicatedTestCases.length)
   const start = performance.now()
   for (const testCase of duplicatedTestCases) {
     overrideTailwindClasses(testCase.input, { ...testCase.options, ruleLookupCache: false } as Options)
   }
   const end = performance.now()
-  console.log(start, end, end - start)
   expect(end - start).toBeLessThan(1000)
 })

--- a/test/performance.test.ts
+++ b/test/performance.test.ts
@@ -24,5 +24,5 @@ test(`overrideTailwindClasses performance`, () => {
     overrideTailwindClasses(testCase.input, testCase.options as Options)
   }
   const end = performance.now()
-  expect(end - start).toBeLessThan(1000)
+  expect(end - start).toBeLessThan(3000)
 })

--- a/test/performance.test.ts
+++ b/test/performance.test.ts
@@ -1,0 +1,32 @@
+/**
+ * @group performance
+ */
+import _ from 'lodash'
+import { performance } from 'perf_hooks'
+import { Options, overrideTailwindClasses } from '../src/index'
+
+import { allTestCases } from './testCases'
+
+test(`overrideTailwindClasses performance`, () => {
+  console.log('number of tests: ', allTestCases.length)
+  const start = performance.now()
+  for (const testCase of allTestCases) {
+    overrideTailwindClasses(testCase.input, { ...testCase.options, ruleLookupCache: false } as Options)
+  }
+  const end = performance.now()
+  console.log(start, end, end - start)
+  expect(end - start).toBeLessThan(300)
+})
+
+const duplicatedTestCases = _.times(1000).flatMap(() => allTestCases)
+
+test(`overrideTailwindClasses performance`, () => {
+  console.log('number of tests: ', duplicatedTestCases.length)
+  const start = performance.now()
+  for (const testCase of duplicatedTestCases) {
+    overrideTailwindClasses(testCase.input, { ...testCase.options, ruleLookupCache: false } as Options)
+  }
+  const end = performance.now()
+  console.log(start, end, end - start)
+  expect(end - start).toBeLessThan(1000)
+})

--- a/test/propertiesVsRules/index.test.ts
+++ b/test/propertiesVsRules/index.test.ts
@@ -23,7 +23,9 @@ const rawTestCases = [
 ]
 
 const testCases = rawTestCases.flatMap((testCase) => {
-  return tailwindVersions.flatMap((version) => [true, false].map((jit) => ({ ...testCase, options: { prefix: testCase.options?.prefix || '', jit }, tailwindVersion: version })))
+  return tailwindVersions.flatMap((version) =>
+    [true, false].map((jit) => ({ ...testCase, options: { prefix: testCase.options?.prefix || '', jit, ruleLookupCache: true }, tailwindVersion: version })),
+  )
 })
 
 for (const testCase of testCases) {

--- a/test/testCases.ts
+++ b/test/testCases.ts
@@ -5,6 +5,7 @@ export const defaultTestCases: TestCase[] = [
   { input: 'apple oranges', expectedOutput: 'apple oranges' },
   { input: 'apple   oranges', expectedOutput: 'apple oranges' },
   { input: 'bg-yellow-600 bg-yellow-700', expectedOutput: 'bg-yellow-700' },
+  { input: 'bg-yellow-600 bg-yellow-700 apple oranges banana mellon', expectedOutput: 'bg-yellow-700 apple oranges banana mellon' },
   { input: 'bg-yellow-600 bg-yellow-700 bg-yellow-800', expectedOutput: 'bg-yellow-800' },
   { input: 'bg-yellow-600   bg-yellow-700', expectedOutput: 'bg-yellow-700' },
   { input: 'w-1/2 w-1/3', expectedOutput: 'w-1/3' },
@@ -51,3 +52,15 @@ export const jitTestCases: TestCase[] = [
   // Not implemented (and other similar cases):
   // { input: 'text-[magenta] text-[32px]', expectedOutput: 'text-[magenta] text-[32px]' },
 ]
+
+export const nonJitTestCases = [...defaultTestCases, ...ruleBasedTestCases].flatMap((testCase) => {
+  return [false, true].map((jit) => ({
+    ...testCase,
+    options: {
+      ...testCase.options,
+      jit: jit,
+    },
+  }))
+})
+
+export const allTestCases = [...nonJitTestCases, ...jitTestCases]


### PR DESCRIPTION
Adds memoization to the slow `getRule` and `findTailwindProperties` functions. This means that if you call the function with the same arguments it won't have to lookup which tailwind properties are impacted again - improving speed.