### PR TITLE
css variables shouldn't clash

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,12 +5,19 @@ const defaultOptions = {
   prefix: '',
   jit: true,
   ruleLookupCache: true,
+  ignoreCssVariables: true,
 }
 
-export type Options = { prefix: string; jit: boolean; ruleLookupCache: boolean }
+export type Options = { prefix: string; jit: boolean; ruleLookupCache: boolean; ignoreCssVariables: boolean }
+
+const isCssVariable = (className) => {
+  return className.startsWith('--')
+}
 
 const findTailwindPropertiesRaw = (className, options: Options) => {
-  return getRules(options).find((rule) => rule.regex.test(className))?.properties
+  return getRules(options)
+    .find((rule) => rule.regex.test(className))
+    ?.properties?.filter((property) => !options.ignoreCssVariables || !isCssVariable(property))
 }
 
 const findTailwindPropertiesMemoized = memoize(findTailwindPropertiesRaw)

--- a/src/useCssProperties/core.ts
+++ b/src/useCssProperties/core.ts
@@ -13,6 +13,10 @@ const isEqualsSorted = (x: string[], y: string[]) => {
   return _.isEqual(_.sortBy(x), _.sortBy(y))
 }
 
+const filterCssVariables = (classNames) => {
+  return classNames?.filter((c) => !c.startsWith('--'))
+}
+
 const doMediaRulesClash = (mediaRule1: string[], mediaRule2: string[]) => {
   return isEqualsSorted(mediaRule1, mediaRule2)
 }
@@ -32,7 +36,7 @@ export const overrideTailwindClasses = (classNamesString: string, optionsArg: Op
         return (
           !doMediaRulesClash(r.tailwindCssRule.topLevelMediaRules, tailwindCssRule.topLevelMediaRules) ||
           !doPseudoElementsClash(r.tailwindCssRule.pseudoElements, tailwindCssRule.pseudoElements) ||
-          !r.tailwindCssRule.properties.some((p) => tailwindCssRule.properties.includes(p))
+          !filterCssVariables(r.tailwindCssRule.properties).some((p) => filterCssVariables(tailwindCssRule.properties).includes(p))
         )
       })
       return [...nonClashingClasses, { class: className, tailwindCssRule: tailwindCssRule }]

--- a/test/arbitaryValuesRules.test.ts
+++ b/test/arbitaryValuesRules.test.ts
@@ -485,7 +485,7 @@ const testCases = [
 for (const testCase of testCases) {
   test(`${testCase.classStartsWith}[value] returns expectedProperties: ${testCase.expectedProperties}`, () => {
     const className = `${testCase.classStartsWith}[value]`
-    const properties = _.sortBy(findTailwindProperties(className, { prefix: '', jit: true, ruleLookupCache: false }))
+    const properties = _.sortBy(findTailwindProperties(className, { prefix: '', jit: true, ruleLookupCache: false, ignoreCssVariables: false }))
     const expectedProperties = _.sortBy(testCase.expectedProperties)
     expect(properties).toStrictEqual(expectedProperties)
   })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6,7 +6,7 @@ import { Options, overrideTailwindClasses } from '../src/index'
 import { allTestCases } from './testCases'
 
 for (const testCase of allTestCases) {
-  test(`overrideTailwindClasses('${testCase.input}', ${testCase.options}) returns '${testCase.expectedOutput}'`, () => {
+  test(`overrideTailwindClasses('${testCase.input}', ${JSON.stringify(testCase.options)}) returns '${testCase.expectedOutput}'`, () => {
     expect(overrideTailwindClasses(testCase.input, testCase.options as Options)).toBe(testCase.expectedOutput)
   })
 }

--- a/test/propertiesVsRules/index.test.ts
+++ b/test/propertiesVsRules/index.test.ts
@@ -24,7 +24,11 @@ const rawTestCases = [
 
 const testCases = rawTestCases.flatMap((testCase) => {
   return tailwindVersions.flatMap((version) =>
-    [true, false].map((jit) => ({ ...testCase, options: { prefix: testCase.options?.prefix || '', jit, ruleLookupCache: true }, tailwindVersion: version })),
+    [true, false].map((jit) => ({
+      ...testCase,
+      options: { prefix: testCase.options?.prefix || '', jit, ruleLookupCache: true, ignoreCssVariables: false },
+      tailwindVersion: version,
+    })),
   )
 })
 

--- a/test/testCases.ts
+++ b/test/testCases.ts
@@ -17,7 +17,7 @@ export const defaultTestCases: TestCase[] = [
   { input: 'pt-4 text-pink-200', expectedOutput: 'pt-4 text-pink-200' },
   { input: 'prefix-pt-2 apple prefix-pt-4 orange', options: { prefix: 'prefix-' }, expectedOutput: 'apple prefix-pt-4 orange' },
   { input: 'md:bg-red-500 md:bg-white', expectedOutput: 'md:bg-white' },
-  { input: 'transform translate-y-0', expectedOutput: 'translate-y-0' },
+  { input: 'transform translate-y-0', expectedOutput: 'transform translate-y-0' },
   { input: 'text-blue-500 focus:text-red-500', expectedOutput: 'text-blue-500 focus:text-red-500' },
   { input: 'text-blue-500 focus:text-red-500 hover:text-red-500', expectedOutput: 'text-blue-500 focus:text-red-500 hover:text-red-500' },
   { input: 'hover:text-blue-500 focus:text-red-500', expectedOutput: 'hover:text-blue-500 focus:text-red-500' },
@@ -27,6 +27,9 @@ export const defaultTestCases: TestCase[] = [
   { input: 'sm:container md:container lg:container', expectedOutput: 'sm:container md:container lg:container' },
   { input: '-inset-y-2.5 inset-y-8', expectedOutput: 'inset-y-8' },
   { input: '-inset-y-2/3 inset-y-8', expectedOutput: 'inset-y-8' },
+  { input: 'text-black text-xl', expectedOutput: 'text-black text-xl' },
+  { input: 'text-black text-xl text-opacity-2', expectedOutput: 'text-black text-xl text-opacity-2' },
+  { input: 'text-xl text-opacity-2', expectedOutput: 'text-xl text-opacity-2' },
 ]
 
 export const ruleBasedTestCases: TestCase[] = [


### PR DESCRIPTION
The library was configured was detecting 'clashes' if css variables clashed.

Example:
```
.text-black {
  --tw-text-opacity: 1;
  color: rgba(0, 0, 0, var(--tw-text-opacity));
}

.text-opacity-5 {
  --tw-text-opacity: 0.05;
}

```

Both include `--tw-text-opacity`, but they're designed to be used together so this isn't a clash.


This change excludes any css variables from the clash check.